### PR TITLE
Always send control if we don't have a status command

### DIFF
--- a/src/blindsCmd-blind.ts
+++ b/src/blindsCmd-blind.ts
@@ -272,8 +272,10 @@ export class Blind {
       return;
     }
 
-    // We're already where we want to be, do nothing.
-    if(value === this.currentPosition) {
+    // We're already where we want to be, do nothing. If we don't have a status command then
+    // we might not know about a manual input to the blind, so send the control even if we think
+    // we're already there.
+    if(this.cmd.status && value === this.currentPosition) {
       this.targetPosition = value;
       this.positionState = Characteristic.PositionState.STOPPED;
 


### PR DESCRIPTION
Thanks for this plugin, it's working really well for me. 

Here's a minor tweak I made that you might also want. For my blinds I have no way to get the current status. Sometimes we'll control them using the controls on the wall, so the status in Homekit will be out of sync with the real world. This change makes it so controls will always be sent if there's no way to get the current status.